### PR TITLE
Filpoll example template

### DIFF
--- a/polls/FIP-70: Enable DataCap Top up for Filecoin Plus Client Addresses.md
+++ b/polls/FIP-70: Enable DataCap Top up for Filecoin Plus Client Addresses.md
@@ -1,0 +1,16 @@
+**Background**
+This poll is to gather the community's sentiment on [FIP-70](https://github.com/filecoin-project/FIPs/issues/70). Discussions about this FIP can be carried out in the original FIP repo issue.
+
+**Proposal**
+Client addresses should be able to receive additional DataCap allocations to a given address.
+
+---
+Options:
+- **< Approve >**: < I approve FIP-70 >
+- **< Reject >**: < I reject FIP-70 >
+
+---
+start: 2021-02-15 19:10
+end: 2021-02-29 00:00
+constituents: [ all ]
+

--- a/polls/FIP-70: Enable DataCap Top up for Filecoin Plus Client Addresses.md
+++ b/polls/FIP-70: Enable DataCap Top up for Filecoin Plus Client Addresses.md
@@ -1,5 +1,5 @@
 **Background**
-This poll is to gather the community's sentiment on [FIP-70](https://github.com/filecoin-project/FIPs/issues/70). Discussions about this FIP can be carried out in the original FIP repo issue.
+This *sample* poll is to gather the community's sentiment on [FIP-70](https://github.com/filecoin-project/FIPs/issues/70). Discussions about this FIP can be carried out in the original FIP repo issue.
 
 **Proposal**
 Client addresses should be able to receive additional DataCap allocations to a given address.
@@ -11,7 +11,7 @@ Options:
 
 ---
 start: 2021-02-15 19:10
-end: 2021-02-29 00:00
+end: 2021-03-29 00:00
 constituents: [ all ]
 author: @jnthnvctr
 discussion: https://github.com/filecoin-project/FIPs/issues/70

--- a/polls/FIP-70: Enable DataCap Top up for Filecoin Plus Client Addresses.md
+++ b/polls/FIP-70: Enable DataCap Top up for Filecoin Plus Client Addresses.md
@@ -13,4 +13,6 @@ Options:
 start: 2021-02-15 19:10
 end: 2021-02-29 00:00
 constituents: [ all ]
+author: @jnthnvctr
+discussion: https://github.com/filecoin-project/FIPs/issues/70
 


### PR DESCRIPTION
FIP creators don't always use a standard template but Filpoll needs one.

But we can reference FIPs in polls on Github that do use this standard Filpoll template.

Rather than creating a separate repo where we create Filpoll polls with standard templates that reference FIPs, it makes sense to do this in community repo, since these are community polls.